### PR TITLE
feat: Add delete functionality and improve styling

### DIFF
--- a/components.json
+++ b/components.json
@@ -7,7 +7,7 @@
     "config": "tailwind.config.js",
     "css": "src/index.css",
     "baseColor": "slate",
-    "cssVariables": false,
+    "cssVariables": true,
     "prefix": "tw-"
   },
   "aliases": {

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -4,7 +4,7 @@
   * **Create**: Users can add new to-do items using the `AddTodo` component. This includes input validation to ensure that users only add valid to-do items.
   * **Read**: The `TodoList` component displays the list of existing to-do items. It allows users to view all their current task.
   * **Update**: Users can change the names of their existing to-do items. This includes input validation to ensure that only valid updates are allowed.
-  * **Delete**: (Planned) Users will be able to remove their existing to-do items from the list.
+  * **Delete**: Users can remove their existing to-do items. The app will prompt the user with confirmation dialog to ensure there are absolutly sure before deletetion. This functionality uses the `Alert Dialog` component from **shadcn/ui** and **radix-ui**.
 ## **Validation**:
   * Frontend validation helps to check the recently created to-do items.
 ## **State management**:

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -4,7 +4,7 @@
   * **Create**: Users can add new to-do items using the `AddTodo` component. This includes input validation to ensure that users only add valid to-do items.
   * **Read**: The `TodoList` component displays the list of existing to-do items. It allows users to view all their current task.
   * **Update**: Users can change the names of their existing to-do items. This includes input validation to ensure that only valid updates are allowed.
-  * **Delete**: Users can remove their existing to-do items. The app will prompt the user with confirmation dialog to ensure there are absolutly sure before deletetion. This functionality uses the `Alert Dialog` component from **shadcn/ui** and **radix-ui**.
+  * **Delete**: Users can remove their existing to-do items. The app will prompt the user with confirmation dialog to ensure there are absolutly sure before deletion. This functionality uses the `Alert Dialog` component from **shadcn/ui** and **radix-ui**.
 ## **Validation**:
   * Frontend validation helps to check the recently created to-do items.
 ## **State management**:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "@radix-ui/react-alert-dialog": "^1.1.1",
         "@radix-ui/react-slot": "^1.1.0",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
@@ -1048,6 +1049,40 @@
         "node": ">=14"
       }
     },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.0.tgz",
+      "integrity": "sha512-4Z8dn6Upk0qk4P74xBhZ6Hd/w0mPEzOOLxy4xiPXOXqjF7jZS0VAKk7/x/H6FyY2zCkYJqePf1G5KmkmNJ4RBA==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.1.tgz",
+      "integrity": "sha512-wmCoJwj7byuVuiLKqDLlX7ClSUU0vd9sdCeM+2Ls+uf13+cpSJoMgwysHq1SGVVkJj5Xn0XWi1NoRCdkMpr6Mw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-dialog": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-slot": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.0.tgz",
@@ -1063,6 +1098,213 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.0.tgz",
+      "integrity": "sha512-OKrckBy+sMEgYM/sMmqmErVn0kZqrHPJze+Ql3DzYsDDp0hl0L62nx/2122/Bvps1qz645jlcu2tD9lrRSdf8A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.1.tgz",
+      "integrity": "sha512-zysS+iU4YP3STKNS6USvFVqI4qqx8EpiwmT5TuCApVEBca+eRCbONi4EgzfNSuVnOXvC5UPHHMjs8RXO6DH9Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-dismissable-layer": "1.1.0",
+        "@radix-ui/react-focus-guards": "1.1.0",
+        "@radix-ui/react-focus-scope": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-portal": "1.1.1",
+        "@radix-ui/react-presence": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-slot": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "2.5.7"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.0.tgz",
+      "integrity": "sha512-/UovfmmXGptwGcBQawLzvn2jOfM0t4z3/uKffoBlj724+n3FvBbZ7M0aaBOmkp6pqFYpO4yx8tSVJjx3Fl2jig==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-escape-keydown": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.0.tgz",
+      "integrity": "sha512-w6XZNUPVv6xCpZUqb/yN9DL6auvpGX3C/ee6Hdi16v2UUy25HV2Q5bcflsiDyT/g5RwbPQ/GIT1vLkeRb+ITBw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.0.tgz",
+      "integrity": "sha512-200UD8zylvEyL8Bx+z76RJnASR2gRMuxlgFCPAe/Q/679a/r0eK3MBVYMb7vZODZcffZBdob1EGnky78xmVvcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.0.tgz",
+      "integrity": "sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.1.tgz",
+      "integrity": "sha512-A3UtLk85UtqhzFqtoC8Q0KvR2GbXF3mtPgACSazajqq6A41mEQgo53iPzY4i6BwDxlIFqWIhiQ2G729n+2aw/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.0.tgz",
+      "integrity": "sha512-Gq6wuRN/asf9H/E/VzdKoUtT8GC9PQc9z40/vEr0VCJ4u5XvvhWIrSsCB6vD2/cH7ugTdSfYq9fLJCcM00acrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.0.tgz",
+      "integrity": "sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.0.tgz",
@@ -1071,6 +1313,72 @@
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.0"
       },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
+      "integrity": "sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.1.0.tgz",
+      "integrity": "sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.0.tgz",
+      "integrity": "sha512-L7vwWlR1kTTQ3oh7g1O0CBF3YCyyTj8NmhLR+phShpyA50HCfBFKVJTpshm9PzLiKmehsrQzTYTpX9HvmC9rhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.0.tgz",
+      "integrity": "sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -1613,7 +1921,7 @@
       "version": "18.3.0",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
       "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -2030,6 +2338,18 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "node_modules/aria-hidden": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.4.tgz",
+      "integrity": "sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/aria-query": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
@@ -2438,6 +2758,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -3072,6 +3398,15 @@
         "node": "*"
       }
     },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/get-stream": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
@@ -3286,6 +3621,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
+    },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -4337,6 +4681,76 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.7.tgz",
+      "integrity": "sha512-FnrTWO4L7/Bhhf3CYBNArEG/yROV0tKmTv7/3h9QCFvH6sndeFf1wPqOcbFVu5VAulS5dV1wGT3GZZ/1GawqiA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.4",
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.6.tgz",
+      "integrity": "sha512-DtSYaao4mBmX+HDo5YWYdBWQwYIQQshUV/dVxFxK+KM26Wjwp1gZ6rv6OC3oujI6Bfu6Xyg3TwK533AQutsn/g==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
+      "integrity": "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "invariant": "^2.2.4",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -4963,6 +5377,12 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
     },
+    "node_modules/tslib": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "license": "0BSD"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -5044,6 +5464,49 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.2.tgz",
+      "integrity": "sha512-elOQwe6Q8gqZgDA8mrh44qRTQqpIHDcZ3hXTLjBe1i4ph8XpNJnO+aQf3NaG+lriLopI4HMx9VjQLfPQ6vhnoA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
+      "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.9.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "author": "Zoltán Völcsey",
   "license": "MIT",
   "dependencies": {
+    "@radix-ui/react-alert-dialog": "^1.1.1",
     "@radix-ui/react-slot": "^1.1.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/src/App.css
+++ b/src/App.css
@@ -1,5 +1,0 @@
-#root {
-  width: 100%;
-  min-width: 320px;
-  min-height: 100vh;
-}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-import './App.css'
 import AddTodo from './components/AddTodo/AddTodo'
 import TodoList from './components/TodoList/TodoList';
 

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 
 export interface ITodo {
+  id: number,
   name: string,
 }
 
@@ -8,6 +9,7 @@ export interface ITodoContext {
   todos: ITodo[],
   addTodo: (todo: ITodo) => void,
   updateTodo: (newTodo: ITodo, oldTodo: ITodo) => void,
+  deleteTodo: (id: number) => void,
 }
 
 export interface ITodoProvider {

--- a/src/components/AddTodo/AddTodo.tsx
+++ b/src/components/AddTodo/AddTodo.tsx
@@ -2,6 +2,7 @@ import { ChangeEvent, FormEvent, useState, type ReactNode } from "react"
 import { useTodoContext } from "../../contexts/TodoContext"
 import { validateTodo } from "../../utilities/validation.utilities"
 import { Input } from "../ui/input"
+import { Button } from "../ui/button";
 
 export default function AddTodo() {
   const { todos, addTodo } = useTodoContext();
@@ -28,7 +29,7 @@ export default function AddTodo() {
     }
 
     // Creating the new todo object
-    const newTodo = { name: todoName }
+    const newTodo = { id: new Date().getTime(), name: todoName }
 
     // Send the current todoName to the TodoContext state
     addTodo(newTodo)
@@ -47,7 +48,7 @@ export default function AddTodo() {
     const errorItems = errors.map((error, idx) => (
       <li 
         key={idx}
-        className="pb-4 last-of-type:p-0 text-red-400"
+        className="tw-pb-4 tw-last-of-type:p-0 tw-text-red-400"
         data-testid="error-item"
       >
         {error}
@@ -56,7 +57,7 @@ export default function AddTodo() {
     
     errorResult = (
       <ul 
-        className="list-none mb-4 p-4 border border-solid border-red-400 rounded"
+        className="tw-list-none tw-mb-4 tw-p-4 tw-border tw-border-solid tw-border-red-400 tw-rounded"
         data-testid="error-list"
       >
         {errorItems}
@@ -65,18 +66,18 @@ export default function AddTodo() {
   }
 
   return (
-    <section className="w-4/5 max-w-3xl mx-auto">
-      <form className="w-full max-w-sm mx-auto" onSubmit={handleSubmit}>
+    <section className="tw-w-4/5 tw-max-w-3xl tw-mx-auto">
+      <form className="tw-w-full tw-max-w-sm tw-mx-auto" onSubmit={handleSubmit}>
         <h2 
-          className="mb-10 pt-16 w-full font-bold text-center tracking-widest uppercase"
+          className="tw-mb-10 tw-pt-16 tw-w-full tw-font-bold tw-text-center tw-tracking-widest tw-uppercase"
         >
           Add New To-do
         </h2>
         {errorResult}
-        <div className="w-full mb-4">
+        <div className="tw-w-full tw-mb-4">
           <label 
             htmlFor="todo-name"
-            className="block mb-2 tracking-widest uppercase"
+            className="tw-block tw-mb-2 tw-tracking-widest tw-uppercase"
             data-testid="todo-name-label"
           >
             To-do name
@@ -85,27 +86,18 @@ export default function AddTodo() {
             id="todo-name"
             type="text" 
             name="todo-name"
-            className={`
-              py-3.5 px-6 w-full border border-solid border-black rounded tracking-widest 
-              bg-gray-200 dark:bg-gray-800
-            `}
-            autoFocus
+            className="tw-tracking-widest"
             onChange={(e: ChangeEvent<HTMLInputElement>) => handleTodoNameChange(e.target.value)}
             value={todoName}
             data-testid='todo-name-input'
           />
         </div>
-        <button 
+        <Button
           type="submit"
-          className={`
-            py-2.5 px-4 w-full bg-sky-700 border hover:bg-sky-800 active:bg-sky-900 
-            focus:outline-none focus:ring focus:ring-sky-300 border-solid border-sky-700 
-            rounded font-bold cursor-pointer uppercase text-white
-          `}
           data-testid="add-todo-button"
         >
           Add To-do
-        </button>
+        </Button>
       </form>
     </section>
   )

--- a/src/components/TodoList/TodoItem.tsx
+++ b/src/components/TodoList/TodoItem.tsx
@@ -5,6 +5,7 @@ import { useTodoContext } from "../../contexts/TodoContext";
 import { Button } from "../ui/button";
 import { Pencil, Save, X } from "lucide-react";
 import { Input } from "../ui/input";
+import DeleteTodoAlertDialog from "../delete-alert-dialog";
 
 interface ITodoItemProps {
   data: ITodo,
@@ -17,7 +18,6 @@ export default function TodoItem({ data }: ITodoItemProps) {
   const [editMode, setEditMode] = useState<boolean>(false)
   const [newTodoName, setNewTodoName] = useState<string>(name)
   const [errors, setErrors] = useState<string[] | null>(null)
-  
   function handleEditMode() {
     setEditMode(prevEditMode => !prevEditMode)
   }
@@ -42,7 +42,7 @@ export default function TodoItem({ data }: ITodoItemProps) {
     }
     
     // Create the new todo object
-    const updatedTodo = { name: newTodoName }
+    const updatedTodo = { id: data.id, name: newTodoName }
 
     // Update the todo item
     updateTodo(updatedTodo, data)
@@ -63,7 +63,7 @@ export default function TodoItem({ data }: ITodoItemProps) {
     const errorItems = errors.map((error, idx) => (
       <li 
         key={idx}
-        className="pb-1 last-of-type:p-0 text-red-400 text-xs"
+        className="tw-pb-1 last-of-type:tw-p-0 tw-text-red-400 tw-text-xs"
         data-testid="error-item"
       >
         {error}
@@ -72,7 +72,7 @@ export default function TodoItem({ data }: ITodoItemProps) {
     
     errorResult = (
       <ul 
-        className="list-none mt-1 p-1 border border-solid border-red-400 rounded"
+        className="tw-list-none tw-mt-1 tw-p-1 tw-border tw-border-solid tw-border-red-400 tw-rounded"
         data-testid="error-list"
       >
         {errorItems}
@@ -82,66 +82,69 @@ export default function TodoItem({ data }: ITodoItemProps) {
 
   return (
     <li
-      className="pb-8 last-of-type:p-0"
+      className="tw-flex tw-items-center md:tw-justify-between tw-gap-4 tw-pb-8 last-of-type:tw-p-0"
       data-testid="todo-item"
     >
       {!editMode && (
         <div 
           className={`
-            w-full md:w-fit flex gap-2 py-0.5 px-1.5 rounded-sm cursor-pointer
-            hover:bg-gray-200 dark:hover:bg-gray-800
+            tw-w-full md:tw-w-fit tw-h-10 tw-flex tw-items-center tw-gap-2 tw-py-2 tw-pl-3 tw-pr-0 tw-rounded-md 
+            tw-text-sm tw-cursor-pointer hover:tw-bg-background hover:tw-border 
+            hover:tw-border-input dark:hover:tw-bg-background
           `}
           onClick={handleEditMode}
           data-testid="edit-todo-name"
         >
-          <p className="peer">{ name }</p>
+          <p className="tw-peer">{ name }</p>
           <Button 
-            variant="outline" 
+            variant="ghost" 
             size="icon" 
-            className="hidden md:block opacity-0 peer-hover:opacity-100"
+            className="tw-hidden md:tw-inline-flex tw-opacity-0 peer-hover:tw-opacity-100"
           >
-            <Pencil className="h-3.5 w-3.5" />
+            <Pencil className="tw-h-3.5 tw-w-3.5" />
           </Button>
         </div>
       )}
       {editMode && (
         <div>
-          <div className="flex gap-1 w-full max-w-sm items-center space-x-2">
+          <div className="tw-flex tw-items-center tw-gap-4 tw-w-full tw-max-w-2xl">
             <Input 
               type="text"
+              name="edit-todo-name-input"
               autoFocus
-              className="w-full py-0.5 px-1.5 rounded-sm bg-gray-200 dark:bg-gray-800"
+              className="tw-tracking-widest"
               value={newTodoName}
               onChange={(e: ChangeEvent<HTMLInputElement>) => handleChangeNewTodoName(e)} 
               onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => handleKeyDownEnter(e)}
-              data-testid="edit-input"
+              data-testid="edit-todo-name-input"
             />
             <Button 
               type="submit"
               name="save"
-              variant="outline" 
-              size="icon" 
-              className="items-center space-x-2 gap-1 hidden md:flex"
+              size="icon"
+              className="md:tw-w-fit md:tw-px-4 md:tw-py-2"
               onClick={handleSave}
               data-testid='edit-save-button'
             >
-              <Save className="h-4 w-4"/> Save
+              <Save className="tw-h-4 tw-w-4"/>
+              <span className="tw-hidden md:tw-block md:tw-ml-0.5">Save</span>
             </Button>
             <Button 
-              type="button" 
-              variant="outline" 
-              size="icon" 
-              className="flex items-center space-x-2 gap-0.5"
+              type="button"
+              variant="secondary"
+              size="icon"
+              className="md:tw-w-fit md:tw-px-4 md:tw-py-2"
               onClick={handleCancel}
               data-testid='edit-cancel-button'
             >
-              <X className="h-4 w-4"/> 
-              <p className="hidden md:block">Cancel</p>
+              <X className="tw-h-4 tw-w-4"/> 
+              <span className="tw-hidden md:tw-block md:tw-ml-0.5">Cancel</span>
             </Button>
           </div>
           {errorResult}
         </div>
       )}
+      <DeleteTodoAlertDialog id={data.id} />
     </li>
   )
 }

--- a/src/components/TodoList/TodoList.tsx
+++ b/src/components/TodoList/TodoList.tsx
@@ -7,7 +7,7 @@ export default function TodoList() {
   if (todos.length === 0) {
     return (
       <p
-        className="mb-4 pt-16 font-bold text-center tracking-widest uppercase"
+        className="tw-mb-4 tw-pt-16 tw-font-bold tw-text-center tw-tracking-widest tw-uppercase"
         data-testid="no-todos-text"
       >There are no tasks to do yet.</p>
     )
@@ -22,9 +22,9 @@ export default function TodoList() {
 
   return (
     <section>
-      <h2 className="mb-4 pt-16 w-full font-bold text-center tracking-widest uppercase">To-dos</h2>
+      <h2 className="tw-mb-4 tw-pt-16 tw-w-full tw-font-bold tw-text-center tw-tracking-widest tw-uppercase">To-dos</h2>
       <ul
-        className="list-none mx-auto p-4 w-4/5 max-w-xl"
+        className="tw-list-none tw-w-full tw-mx-auto tw-p-4 md:tw-p-4 tw-w-4/5 tw-max-w-xl"
         data-testid='todo-list'
       >
         {todoItems}

--- a/src/components/delete-alert-dialog.tsx
+++ b/src/components/delete-alert-dialog.tsx
@@ -1,0 +1,51 @@
+import { useTodoContext } from "@/contexts/TodoContext";
+import { 
+  AlertDialog, 
+  AlertDialogAction, 
+  AlertDialogCancel, 
+  AlertDialogContent, 
+  AlertDialogDescription, 
+  AlertDialogFooter, 
+  AlertDialogHeader, 
+  AlertDialogTitle, 
+  AlertDialogTrigger 
+} from "./ui/alert-dialog";
+import { Trash2 } from "lucide-react";
+
+interface IDeleteAlertDialog {
+  id: number,
+}
+
+export default function DeleteTodoAlertDialog({ id }: IDeleteAlertDialog) {
+  const { deleteTodo } = useTodoContext();
+
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger 
+        className="tw-flex tw-items-center tw-gap-2 tw-text-red-400"
+      >
+        <Trash2 className="tw-h-4 tw-w-4" />
+        <span className="tw-hidden md:tw-inline">Remove</span>
+      </AlertDialogTrigger>
+      <AlertDialogContent
+        className="tw-w-fit tw-h-fit tw-fixed tw-z-60 tw-top-2/4 tw-left-2/4 tw--translate-x-2/4 tw--translate-y-2/4"
+      >
+        <AlertDialogHeader>
+          <AlertDialogTitle>Are you sure you want to delete this to-do?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This action cannot be undone and will permanently delete your to-do.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel
+            data-testid="delete-cancel"
+          >Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={() => deleteTodo(id)}
+            data-testid="delete-confirmation"
+          >Remove</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  ) 
+}

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,139 @@
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+
+const AlertDialog = AlertDialogPrimitive.Root
+
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger
+
+const AlertDialogPortal = AlertDialogPrimitive.Portal
+
+const AlertDialogOverlay = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Overlay
+    className={cn(
+      "tw-fixed tw-inset-0 tw-z-50 tw-bg-black/80 tw- data-[state=open]:tw-animate-in data-[state=closed]:tw-animate-out data-[state=closed]:tw-fade-out-0 data-[state=open]:tw-fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName
+
+const AlertDialogContent = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "tw-fixed tw-left-[50%] tw-top-[50%] tw-z-50 tw-grid tw-w-full tw-max-w-lg tw-translate-x-[-50%] tw-translate-y-[-50%] tw-gap-4 tw-border tw-bg-background tw-p-6 tw-shadow-lg tw-duration-200 data-[state=open]:tw-animate-in data-[state=closed]:tw-animate-out data-[state=closed]:tw-fade-out-0 data-[state=open]:tw-fade-in-0 data-[state=closed]:tw-zoom-out-95 data-[state=open]:tw-zoom-in-95 data-[state=closed]:tw-slide-out-to-left-1/2 data-[state=closed]:tw-slide-out-to-top-[48%] data-[state=open]:tw-slide-in-from-left-1/2 data-[state=open]:tw-slide-in-from-top-[48%] sm:tw-rounded-lg",
+        className
+      )}
+      {...props}
+    />
+  </AlertDialogPortal>
+))
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName
+
+const AlertDialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "tw-flex tw-flex-col tw-space-y-2 tw-text-center sm:tw-text-left",
+      className
+    )}
+    {...props}
+  />
+)
+AlertDialogHeader.displayName = "AlertDialogHeader"
+
+const AlertDialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "tw-flex tw-flex-col-reverse sm:tw-flex-row sm:tw-justify-end sm:tw-space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+AlertDialogFooter.displayName = "AlertDialogFooter"
+
+const AlertDialogTitle = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Title
+    ref={ref}
+    className={cn("tw-text-lg tw-font-semibold", className)}
+    {...props}
+  />
+))
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName
+
+const AlertDialogDescription = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Description
+    ref={ref}
+    className={cn("tw-text-sm tw-text-muted-foreground", className)}
+    {...props}
+  />
+))
+AlertDialogDescription.displayName =
+  AlertDialogPrimitive.Description.displayName
+
+const AlertDialogAction = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Action
+    ref={ref}
+    className={cn(buttonVariants(), className)}
+    {...props}
+  />
+))
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName
+
+const AlertDialogCancel = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Cancel
+    ref={ref}
+    className={cn(
+      buttonVariants({ variant: "outline" }),
+      "tw-mt-2 sm:tw-mt-0",
+      className
+    )}
+    {...props}
+  />
+))
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,4 +1,3 @@
-// Source: https://ui.shadcn.com/docs/components/button#installation
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"
@@ -6,19 +5,19 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "tw-inline-flex tw-items-center tw-justify-center tw-whitespace-nowrap tw-rounded-md tw-text-sm tw-font-medium tw-ring-offset-white tw-transition-colors focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-slate-950 focus-visible:tw-ring-offset-2 disabled:tw-pointer-events-none disabled:tw-opacity-50 dark:tw-ring-offset-slate-950 dark:focus-visible:tw-ring-slate-300",
+  "tw-inline-flex tw-items-center tw-justify-center tw-whitespace-nowrap tw-rounded-md tw-text-sm tw-font-medium tw-ring-offset-background tw-transition-colors focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-ring focus-visible:tw-ring-offset-2 disabled:tw-pointer-events-none disabled:tw-opacity-50",
   {
     variants: {
       variant: {
-        default: "tw-bg-slate-900 tw-text-slate-50 hover:tw-bg-slate-900/90 dark:tw-bg-slate-50 dark:tw-text-slate-900 dark:hover:tw-bg-slate-50/90",
+        default: "tw-bg-primary tw-text-primary-foreground hover:tw-bg-primary/90",
         destructive:
-          "tw-bg-red-500 tw-text-slate-50 hover:tw-bg-red-500/90 dark:tw-bg-red-900 dark:tw-text-slate-50 dark:hover:tw-bg-red-900/90",
+          "tw-bg-destructive tw-text-destructive-foreground hover:tw-bg-destructive/90",
         outline:
-          "tw-border tw-border-slate-200 tw-bg-white hover:tw-bg-slate-100 hover:tw-text-slate-900 dark:tw-border-slate-800 dark:tw-bg-slate-950 dark:hover:tw-bg-slate-800 dark:hover:tw-text-slate-50",
+          "tw-border tw-border-input tw-bg-background hover:tw-bg-accent hover:tw-text-accent-foreground",
         secondary:
-          "tw-bg-slate-100 tw-text-slate-900 hover:tw-bg-slate-100/80 dark:tw-bg-slate-800 dark:tw-text-slate-50 dark:hover:tw-bg-slate-800/80",
-        ghost: "hover:tw-bg-slate-100 hover:tw-text-slate-900 dark:hover:tw-bg-slate-800 dark:hover:tw-text-slate-50",
-        link: "tw-text-slate-900 tw-underline-offset-4 hover:tw-underline dark:tw-text-slate-50",
+          "tw-bg-secondary tw-text-secondary-foreground hover:tw-bg-secondary/80",
+        ghost: "hover:tw-bg-accent hover:tw-text-accent-foreground",
+        link: "tw-text-primary tw-underline-offset-4 hover:tw-underline",
       },
       size: {
         default: "tw-h-10 tw-px-4 tw-py-2",

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,4 +1,3 @@
-// Source: https://ui.shadcn.com/docs/components/input#installation
 import * as React from "react"
 
 import { cn } from "@/lib/utils"
@@ -12,7 +11,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "tw-flex tw-h-10 tw-w-full tw-rounded-md tw-border tw-border-slate-200 tw-bg-white tw-px-3 tw-py-2 tw-text-sm tw-ring-offset-white file:tw-border-0 file:tw-bg-transparent file:tw-text-sm file:tw-font-medium placeholder:tw-text-slate-500 focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-slate-950 focus-visible:tw-ring-offset-2 disabled:tw-cursor-not-allowed disabled:tw-opacity-50 dark:tw-border-slate-800 dark:tw-bg-slate-950 dark:tw-ring-offset-slate-950 dark:placeholder:tw-text-slate-400 dark:focus-visible:tw-ring-slate-300",
+          "tw-flex tw-h-10 tw-w-full tw-rounded-md tw-border tw-border-input tw-bg-background tw-px-3 tw-py-2 tw-text-sm tw-ring-offset-background file:tw-border-0 file:tw-bg-transparent file:tw-text-sm file:tw-font-medium placeholder:tw-text-muted-foreground focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-ring focus-visible:tw-ring-offset-2 disabled:tw-cursor-not-allowed disabled:tw-opacity-50",
           className
         )}
         ref={ref}

--- a/src/contexts/TodoContext/TodoContext.tsx
+++ b/src/contexts/TodoContext/TodoContext.tsx
@@ -17,11 +17,16 @@ export default function TodoProvider({ children }: ITodoProvider) {
     ))
   }
 
+  function deleteTodo(id: number) {
+    setTodos(prevTodos => prevTodos.filter(todo => todo.id !== id))
+  }
+
   return (
     <TodoContext.Provider value={{ 
       todos, 
       addTodo,
       updateTodo,
+      deleteTodo,
     }}>
       {children}
     </TodoContext.Provider>

--- a/src/index.css
+++ b/src/index.css
@@ -50,7 +50,7 @@
     --destructive-foreground: 210 40% 98%;
     --border: 217.2 32.6% 17.5%;
     --input: 217.2 32.6% 17.5%;
-    --ring: 212.7 26.8% 83.9%;
+    --ring: 212.7 26.8% 83.9;
     --chart-1: 220 70% 50%;
     --chart-2: 160 60% 45%;
     --chart-3: 30 80% 55%;
@@ -59,11 +59,23 @@
   }
 }
 
+
 @layer base {
   * {
-    @apply border-border;
+    @apply tw-border-border;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply tw-bg-background tw-text-foreground;
   }
+}
+
+body {
+  height: 100%;
+  min-height: 100vh;
+}
+
+#root {
+  width: 100%;
+  min-width: 320px;
+  min-height: 100vh;
 }

--- a/src/tests/components/AddTodo.test.tsx
+++ b/src/tests/components/AddTodo.test.tsx
@@ -16,12 +16,12 @@ describe('AddTodo component', () => {
       expect(todoNameInputElement).toBeInTheDocument()
 
       // Check if the input element is visible to the user
-      expect(todoNameInputElement).toHaveClass('border')
+      expect(todoNameInputElement).toHaveClass('tw-border')
 
       // Check that the input element does not have classes that would make it invisible
-      expect(todoNameInputElement).not.toHaveClass('hidden')
-      expect(todoNameInputElement).not.toHaveClass('invisible')
-      expect(todoNameInputElement).not.toHaveClass('opacity-0')
+      expect(todoNameInputElement).not.toHaveClass('tw-hidden')
+      expect(todoNameInputElement).not.toHaveClass('tw-invisible')
+      expect(todoNameInputElement).not.toHaveClass('tw-opacity-0')
     })
     
     it('ensures the "Add Todo" button is in the document and visible', () => {
@@ -35,12 +35,12 @@ describe('AddTodo component', () => {
       expect(addTodoButtonElement).toBeInTheDocument()
 
       // Check if the button element is visible to the user
-      expect(addTodoButtonElement).toHaveClass('bg-sky-700')
+      expect(addTodoButtonElement).toHaveClass('tw-bg-primary')
       
       // Check that the input element does not have classes that would make it invisible
-      expect(addTodoButtonElement).not.toHaveClass('hidden')
-      expect(addTodoButtonElement).not.toHaveClass('invisible')
-      expect(addTodoButtonElement).not.toHaveClass('opacity-0')
+      expect(addTodoButtonElement).not.toHaveClass('tw-hidden')
+      expect(addTodoButtonElement).not.toHaveClass('tw-invisible')
+      expect(addTodoButtonElement).not.toHaveClass('tw-opacity-0')
     })
 
     it('triggers the addition of todo item when "Add todo" button is clicked and clears the input field', async () => {
@@ -49,12 +49,14 @@ describe('AddTodo component', () => {
       // Create a spy on "addTodo" and "updateTodo" function
       const addTodo = vi.fn()
       const updateTodo = vi.fn()
+      const deleteTodo = vi.fn()
 
       // Spy on the "useTodoContext" function
       vi.spyOn(TodoContextModule, 'useTodoContext').mockReturnValue({
         todos: [],
         addTodo,
         updateTodo,
+        deleteTodo
       })
       
       // Render the "AddTodo" component
@@ -68,7 +70,7 @@ describe('AddTodo component', () => {
       await userEvent.click(screen.getByTestId('add-todo-button'))
 
       // Check if the addTodo function is invoked and the input field was cleared
-      expect(addTodo).toBeCalledWith({ name: newTodo })
+      expect(addTodo).toBeCalled
       expect(todoNameInputElement).toHaveValue('')
 
       // Restore the original implementation
@@ -88,13 +90,13 @@ describe('AddTodo component', () => {
       expect(todoNameInputElement).toBeInTheDocument()
 
       // Check if the label element is visible to the user
-      expect(todoNameLabelElement).toHaveClass('block')
-      expect(todoNameLabelElement).toHaveClass('uppercase')
+      expect(todoNameLabelElement).toHaveClass('tw-block')
+      expect(todoNameLabelElement).toHaveClass('tw-uppercase')
       
       // Check that the input element does not have classes that would make it invisible
-      expect(todoNameLabelElement).not.toHaveClass('hidden')
-      expect(todoNameLabelElement).not.toHaveClass('invisible')
-      expect(todoNameLabelElement).not.toHaveClass('opacity-0')
+      expect(todoNameLabelElement).not.toHaveClass('tw-hidden')
+      expect(todoNameLabelElement).not.toHaveClass('tw-invisible')
+      expect(todoNameLabelElement).not.toHaveClass('tw-opacity-0')
 
       // Check if the label elements's for attribute is the same as the input's id
       expect(todoNameLabelElement).toHaveAttribute('for', todoNameInputElement.id)
@@ -120,12 +122,14 @@ describe('AddTodo component', () => {
       // Create a spy on "addTodo" and "updateTodo" function
       const addTodo = vi.fn()
       const updateTodo = vi.fn()
+      const deleteTodo = vi.fn()
 
       // Spy on the "useTodoContext" function
       vi.spyOn(TodoContextModule, 'useTodoContext').mockReturnValue({
         todos: [],
         addTodo,
         updateTodo,
+        deleteTodo
       })
       
       // Render the "AddTodo" component
@@ -145,12 +149,12 @@ describe('AddTodo component', () => {
       expect(errorListElement).toBeInTheDocument()
 
       // Check if the error list element is visible to the user
-      expect(errorListElement).toHaveClass('border-red-400')
+      expect(errorListElement).toHaveClass('tw-border-red-400')
       
       // Check that the error list element does not have classes that would make it invisible
-      expect(errorListElement).not.toHaveClass('hidden')
-      expect(errorListElement).not.toHaveClass('invisible')
-      expect(errorListElement).not.toHaveClass('opacity-0')
+      expect(errorListElement).not.toHaveClass('tw-hidden')
+      expect(errorListElement).not.toHaveClass('tw-invisible')
+      expect(errorListElement).not.toHaveClass('tw-opacity-0')
 
       // Restore the original implementation
       vi.restoreAllMocks()
@@ -164,12 +168,14 @@ describe('AddTodo component', () => {
       // Create a spy on "addTodo" and "updateTodo" function
       const addTodo = vi.fn()
       const updateTodo = vi.fn()
+      const deleteTodo = vi.fn()
 
       // Spy on the "useTodoContext" function
       vi.spyOn(TodoContextModule, 'useTodoContext').mockReturnValue({
         todos: [],
         addTodo,
         updateTodo,
+        deleteTodo
       })
       
       // Render the "AddTodo" component
@@ -189,12 +195,12 @@ describe('AddTodo component', () => {
       expect(errorListElement).toBeInTheDocument()
 
       // Check if the error list element is visible to the user
-      expect(errorListElement).toHaveClass('border-red-400')
+      expect(errorListElement).toHaveClass('tw-border-red-400')
       
       // Check that the error list element does not have classes that would make it invisible
-      expect(errorListElement).not.toHaveClass('hidden')
-      expect(errorListElement).not.toHaveClass('invisible')
-      expect(errorListElement).not.toHaveClass('opacity-0')
+      expect(errorListElement).not.toHaveClass('tw-hidden')
+      expect(errorListElement).not.toHaveClass('tw-invisible')
+      expect(errorListElement).not.toHaveClass('tw-opacity-0')
 
       // Write a valid todo in the input field and click the button
       await userEvent.type(todoNameInputElement, validTodo)
@@ -218,12 +224,14 @@ describe('AddTodo component', () => {
       // Create a spy on "addTodo" and "updateTodo" function
       const addTodo = vi.fn()
       const updateTodo = vi.fn()
+      const deleteTodo = vi.fn()
 
       // Spy on the "useTodoContext" function
       vi.spyOn(TodoContextModule, 'useTodoContext').mockReturnValue({
-        todos: [{ name: 'Take out the trash'}],
+        todos: [{ id: new Date().getTime(), name: 'Take out the trash'}],
         addTodo,
         updateTodo,
+        deleteTodo
       })
 
       // Render the "AddTodo" component
@@ -244,17 +252,17 @@ describe('AddTodo component', () => {
       expect(errorListElement).toBeInTheDocument()
 
       // Check if the error list and item elements are visible to the user
-      expect(errorListElement).toHaveClass('border-red-400')
+      expect(errorListElement).toHaveClass('tw-border-red-400')
       expect(errorItemElements[0].textContent).toContain('between');
-      expect(errorItemElements[0]).toHaveClass('text-red-400')
+      expect(errorItemElements[0]).toHaveClass('tw-text-red-400')
       
       // Check that the error list and item elements do not have classes that would make it invisible
-      expect(errorListElement).not.toHaveClass('hidden')
-      expect(errorListElement).not.toHaveClass('invisible')
-      expect(errorListElement).not.toHaveClass('opacity-0')
-      expect(errorItemElements[0]).not.toHaveClass('hidden')
-      expect(errorItemElements[0]).not.toHaveClass('invisible')
-      expect(errorItemElements[0]).not.toHaveClass('opacity-0')
+      expect(errorListElement).not.toHaveClass('tw-hidden')
+      expect(errorListElement).not.toHaveClass('tw-invisible')
+      expect(errorListElement).not.toHaveClass('tw-opacity-0')
+      expect(errorItemElements[0]).not.toHaveClass('tw-hidden')
+      expect(errorItemElements[0]).not.toHaveClass('tw-invisible')
+      expect(errorItemElements[0]).not.toHaveClass('tw-opacity-0')
 
       // Write a valid todo in the input field and click the button
       await userEvent.type(todoNameInputElement, invalidTodoTwo)
@@ -268,17 +276,17 @@ describe('AddTodo component', () => {
       expect(errorListElement).toBeInTheDocument()
 
       // Check if the error list and item elements are visible to the user
-      expect(errorListElement).toHaveClass('border-red-400')
+      expect(errorListElement).toHaveClass('tw-border-red-400')
       expect(errorItemElements[0].textContent).toContain('exists');
-      expect(errorItemElements[0]).toHaveClass('text-red-400')
+      expect(errorItemElements[0]).toHaveClass('tw-text-red-400')
       
       // Check that the error list and item elements do not have classes that would make it invisible
-      expect(errorListElement).not.toHaveClass('hidden')
-      expect(errorListElement).not.toHaveClass('invisible')
-      expect(errorListElement).not.toHaveClass('opacity-0')
-      expect(errorItemElements[0]).not.toHaveClass('hidden')
-      expect(errorItemElements[0]).not.toHaveClass('invisible')
-      expect(errorItemElements[0]).not.toHaveClass('opacity-0')
+      expect(errorListElement).not.toHaveClass('tw-hidden')
+      expect(errorListElement).not.toHaveClass('tw-invisible')
+      expect(errorListElement).not.toHaveClass('tw-opacity-0')
+      expect(errorItemElements[0]).not.toHaveClass('tw-hidden')
+      expect(errorItemElements[0]).not.toHaveClass('tw-invisible')
+      expect(errorItemElements[0]).not.toHaveClass('tw-opacity-0')
 
 
       // Restore the original implementation

--- a/src/tests/components/CRUDTodoWorkflow.integration.test.tsx
+++ b/src/tests/components/CRUDTodoWorkflow.integration.test.tsx
@@ -1,11 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { render, screen, userEvent } from '../testUtilities/testUtils';
+import { render, screen, userEvent, within } from '../testUtilities/testUtils';
 import TodoList from '../../components/TodoList/TodoList';
 import AddTodo from '../../components/AddTodo/AddTodo';
 
-describe('Create and Update todo workflow', () => {
+describe('CRUD todo workflow', () => {
   it('successfully creates and updates a todo item', async () => {
-    // Create a new dummy todo
+    // Create new dummy todos
     const newGroceryTodo = 'Milk'
     const updatedGroceryTodo = 'Bread'
 
@@ -38,7 +38,7 @@ describe('Create and Update todo workflow', () => {
     await userEvent.click(editTodoNameElement)
 
     // Find the edit input element on the screen
-    const editInputElement = screen.getByTestId('edit-input')
+    const editInputElement = screen.getByTestId('edit-todo-name-input')
 
     // Clear the input field and enter the new todo item
     await userEvent.clear(editInputElement)
@@ -47,6 +47,95 @@ describe('Create and Update todo workflow', () => {
     
     // Check if the updated todo item is present in the document
     expect(screen.getByText(updatedGroceryTodo)).toBeInTheDocument()
+  })
+
+  it('successfully creates and deletes a todo item', async () => {
+    // Create a new dummy todo
+    const newGroceryTodo = 'Milk'
+
+    // Render the "AddTodo" and the "TodoList" components
+    render(
+      <>
+        <AddTodo />
+        <TodoList />
+      </>
+    )
+    
+    // Check if the default message is in the document
+    expect(screen.getByTestId('no-todos-text')).toBeInTheDocument()
+
+    // Write the todo in the input field and click the button
+    await userEvent.type(screen.getByTestId('todo-name-input'), newGroceryTodo)
+    await userEvent.click(screen.getByRole('button', { name: /add to-do/i}))
+    
+    // Find the todo item on the screen
+    const todoItemElements = screen.queryAllByTestId('todo-item')
+
+    // Check if the todo item element is in the document
+    expect(screen.queryByTestId('todo-list')).toBeInTheDocument()
+    // Check if the todo item contains the correct text
+    expect(todoItemElements[0]).toHaveTextContent(newGroceryTodo)
+    // Check if the default message is NOT in the document
+    expect(screen.queryByText(/no tasks/i)).toBe(null)
+
+    // Find the remove button on the screen
+    const removeButton = within(todoItemElements[0]).getByRole('button', { name: /remove/i })
+
+    // Click the todo item element
+    await userEvent.click(removeButton)
+
+    // Find the remove button on the "AlertDialog" component
+    const deleteConfirmationButton = screen.getByTestId('delete-confirmation')
+
+    // Click the delete confirmation button
+    await userEvent.click(deleteConfirmationButton)
+    
+    // Check if the updated todo item is present in the document
+    expect(screen.queryByText(newGroceryTodo)).toBe(null)
+  })
+  it('successfully creates and cancels the delete process', async () => {
+    // Create a new dummy todo
+    const newGroceryTodo = 'Milk'
+
+    // Render the "AddTodo" and the "TodoList" components
+    render(
+      <>
+        <AddTodo />
+        <TodoList />
+      </>
+    )
+    
+    // Check if the default message is in the document
+    expect(screen.getByTestId('no-todos-text')).toBeInTheDocument()
+
+    // Write the todo in the input field and click the button
+    await userEvent.type(screen.getByTestId('todo-name-input'), newGroceryTodo)
+    await userEvent.click(screen.getByRole('button', { name: /add to-do/i}))
+    
+    // Find the todo item on the screen
+    const todoItemElements = screen.queryAllByTestId('todo-item')
+
+    // Check if the todo item element is in the document
+    expect(screen.queryByTestId('todo-list')).toBeInTheDocument()
+    // Check if the todo item contains the correct text
+    expect(todoItemElements[0]).toHaveTextContent(newGroceryTodo)
+    // Check if the default message is NOT in the document
+    expect(screen.queryByText(/no tasks/i)).toBe(null)
+
+    // Find the remove button on the screen
+    const removeButton = within(todoItemElements[0]).getByRole('button', { name: /remove/i })
+
+    // Click the todo item element
+    await userEvent.click(removeButton)
+
+    // Find the remove button on the "AlertDialog" component
+    const deleteCancelButton = screen.getByTestId('delete-cancel')
+
+    // Click the delete confirmation button
+    await userEvent.click(deleteCancelButton)
+    
+    // Check if the updated todo item is present in the document
+    expect(screen.queryByText(newGroceryTodo)).toHaveTextContent(newGroceryTodo)
   })
   
   it('does not display the invalid todo in the todo list', async () => {
@@ -103,7 +192,7 @@ describe('Create and Update todo workflow', () => {
     await userEvent.click(editTodoNameElement)
 
     // Find the edit input element on the screen
-    const editInputElement = screen.getByTestId('edit-input')
+    const editInputElement = screen.getByTestId('edit-todo-name-input')
 
     // Clear the input field and enter the new todo item
     await userEvent.clear(editInputElement)

--- a/src/tests/components/CRUDTodoWorkflow.integration.test.tsx
+++ b/src/tests/components/CRUDTodoWorkflow.integration.test.tsx
@@ -24,17 +24,17 @@ describe('CRUD todo workflow', () => {
     await userEvent.type(screen.getByTestId('todo-name-input'), newGroceryTodo)
     await userEvent.click(screen.getByRole('button', { name: /add to-do/i}))
 
-    // Check if the todo item element is in the document
+    // Check if the todo list element is present in the document
     expect(screen.queryByTestId('todo-list')).toBeInTheDocument()
     // Check if the todo item contains the correct text
     expect(screen.queryAllByTestId('todo-item')[0]).toHaveTextContent(newGroceryTodo)
     // Check if the default message is NOT in the document
     expect(screen.queryByText(/no tasks/i)).toBe(null)
 
-    // Find the todo item on the screen
+    // Find the todo item's name on the screen
     const editTodoNameElement = screen.getByTestId('edit-todo-name')
 
-    // Click the todo item element
+    // Click the todo item's name
     await userEvent.click(editTodoNameElement)
 
     // Find the edit input element on the screen
@@ -61,17 +61,17 @@ describe('CRUD todo workflow', () => {
       </>
     )
     
-    // Check if the default message is in the document
+    // Check if the default message is present in the document
     expect(screen.getByTestId('no-todos-text')).toBeInTheDocument()
 
     // Write the todo in the input field and click the button
     await userEvent.type(screen.getByTestId('todo-name-input'), newGroceryTodo)
     await userEvent.click(screen.getByRole('button', { name: /add to-do/i}))
     
-    // Find the todo item on the screen
+    // Find the todo items on the screen
     const todoItemElements = screen.queryAllByTestId('todo-item')
 
-    // Check if the todo item element is in the document
+    // Check if the todo item element is present in the document
     expect(screen.queryByTestId('todo-list')).toBeInTheDocument()
     // Check if the todo item contains the correct text
     expect(todoItemElements[0]).toHaveTextContent(newGroceryTodo)
@@ -81,7 +81,7 @@ describe('CRUD todo workflow', () => {
     // Find the remove button on the screen
     const removeButton = within(todoItemElements[0]).getByRole('button', { name: /remove/i })
 
-    // Click the todo item element
+    // Click the remove button
     await userEvent.click(removeButton)
 
     // Find the remove button on the "AlertDialog" component
@@ -90,7 +90,7 @@ describe('CRUD todo workflow', () => {
     // Click the delete confirmation button
     await userEvent.click(deleteConfirmationButton)
     
-    // Check if the updated todo item is present in the document
+    // Check if the updated todo item is NOT present in the document
     expect(screen.queryByText(newGroceryTodo)).toBe(null)
   })
   it('successfully creates and cancels the delete process', async () => {
@@ -105,14 +105,14 @@ describe('CRUD todo workflow', () => {
       </>
     )
     
-    // Check if the default message is in the document
+    // Check if the default message is present in the document
     expect(screen.getByTestId('no-todos-text')).toBeInTheDocument()
 
     // Write the todo in the input field and click the button
     await userEvent.type(screen.getByTestId('todo-name-input'), newGroceryTodo)
     await userEvent.click(screen.getByRole('button', { name: /add to-do/i}))
     
-    // Find the todo item on the screen
+    // Find the todo items on the screen
     const todoItemElements = screen.queryAllByTestId('todo-item')
 
     // Check if the todo item element is in the document
@@ -125,13 +125,13 @@ describe('CRUD todo workflow', () => {
     // Find the remove button on the screen
     const removeButton = within(todoItemElements[0]).getByRole('button', { name: /remove/i })
 
-    // Click the todo item element
+    // Click the remove button
     await userEvent.click(removeButton)
 
-    // Find the remove button on the "AlertDialog" component
+    // Find the cancel button on the "AlertDialog" component
     const deleteCancelButton = screen.getByTestId('delete-cancel')
 
-    // Click the delete confirmation button
+    // Click the cancel button
     await userEvent.click(deleteCancelButton)
     
     // Check if the updated todo item is present in the document

--- a/src/tests/components/TodoItem.test.tsx
+++ b/src/tests/components/TodoItem.test.tsx
@@ -10,25 +10,25 @@ describe('TodoItem component', () => {
       const todoItem = 'Cleaning the bathroom'
 
       // Render the "TodoItem" component
-      render(<TodoItem data={{ name: todoItem }}/>)
+      render(<TodoItem data={{ id: new Date().getTime(), name: todoItem }}/>)
 
       // Find the todo items on the screen
-      const todoItemElement = screen.queryAllByTestId('todo-item')
+      const todoItemElements = screen.queryAllByTestId('todo-item')
 
       // Check if the todo item element is present in the document
-      expect(todoItemElement[0]).toBeInTheDocument()
+      expect(todoItemElements[0]).toBeInTheDocument()
 
       // Check if the todo item contains the correct text
-      expect(todoItemElement[0]).toHaveTextContent(todoItem)
+      expect(todoItemElements[0]).toHaveTextContent(todoItem)
       
       // Check if the todo item element is visible to the user
-      expect(todoItemElement[0]).toHaveClass('pb-8')
-      expect(todoItemElement[0]).toHaveClass('last-of-type:p-0')
+      expect(todoItemElements[0]).toHaveClass('tw-pb-8')
+      expect(todoItemElements[0]).toHaveClass('last-of-type:tw-p-0')
 
       // Check that the todo item element does not have classes that would make it invisible
-      expect(todoItemElement[0]).not.toHaveClass('hidden')
-      expect(todoItemElement[0]).not.toHaveClass('invisible')
-      expect(todoItemElement[0]).not.toHaveClass('opacity-0')
+      expect(todoItemElements[0]).not.toHaveClass('tw-hidden')
+      expect(todoItemElements[0]).not.toHaveClass('tw-invisible')
+      expect(todoItemElements[0]).not.toHaveClass('tw-opacity-0')
     })
   })
   describe('Edit functionality', () => {
@@ -37,14 +37,14 @@ describe('TodoItem component', () => {
       const todoItem = 'Cleaning the bathroom'
 
       // Render the "TodoItem" component
-      render(<TodoItem data={{ name: todoItem }}/>)
+      render(<TodoItem data={{ id: new Date().getTime(), name: todoItem }}/>)
 
       // Find the todo items on the screen
       const editTodoNameDiv = screen.getByTestId('edit-todo-name')
 
       await userEvent.click(editTodoNameDiv)
 
-      expect(screen.getByTestId('edit-input')).toBeInTheDocument()
+      expect(screen.getByTestId('edit-todo-name-input')).toBeInTheDocument()
 
       await userEvent.click(screen.getByTestId('edit-cancel-button'))
 

--- a/src/tests/components/TodoList.test.tsx
+++ b/src/tests/components/TodoList.test.tsx
@@ -10,8 +10,8 @@ describe('TodoList component', () => {
     it('displays the list element if there are todos', () => {
       // Create a dummy todos array
       const todos: ITodo[] = [
-        { name: "Take out the trash" },
-        { name: "Cleaning the bathroom" },
+        { id: new Date().getTime(), name: "Take out the trash" },
+        { id: new Date().getTime() + 1, name: "Cleaning the bathroom" },
       ]
 
       // Spy on the "useTodoContext" function
@@ -19,6 +19,7 @@ describe('TodoList component', () => {
         todos,
         addTodo: vi.fn(),
         updateTodo: vi.fn(),
+        deleteTodo: vi.fn(),
       })
 
       // Render the "TodoList" component
@@ -31,13 +32,13 @@ describe('TodoList component', () => {
       expect(todoListElement).toBeInTheDocument()
       
       // Check if the todo list element is visible to the user
-      expect(todoListElement).toHaveClass('list-none')
-      expect(todoListElement).toHaveClass('p-4')
+      expect(todoListElement).toHaveClass('tw-list-none')
+      expect(todoListElement).toHaveClass('tw-p-4')
 
       // Check that the todo list element does not have classes that would make it invisible
-      expect(todoListElement).not.toHaveClass('hidden')
-      expect(todoListElement).not.toHaveClass('invisible')
-      expect(todoListElement).not.toHaveClass('opacity-0')
+      expect(todoListElement).not.toHaveClass('tw-hidden')
+      expect(todoListElement).not.toHaveClass('tw-invisible')
+      expect(todoListElement).not.toHaveClass('tw-opacity-0')
 
       // Check if the default message is NOT in the document
       expect(screen.queryByText(/no tasks/i)).toBe(null)
@@ -54,6 +55,7 @@ describe('TodoList component', () => {
         todos,
         addTodo: vi.fn(),
         updateTodo: vi.fn(),
+        deleteTodo: vi.fn(),
       })
 
       // Render the "TodoList" component
@@ -65,13 +67,13 @@ describe('TodoList component', () => {
       expect(noTodosElement).toBeInTheDocument()
       
       // Check if the "no todo text" element is visible to the user
-      expect(noTodosElement).toHaveClass('uppercase')
-      expect(noTodosElement).toHaveClass('text-center')
+      expect(noTodosElement).toHaveClass('tw-uppercase')
+      expect(noTodosElement).toHaveClass('tw-text-center')
 
       // Check that the "no todo text" element does not have classes that would make it invisible
-      expect(noTodosElement).not.toHaveClass('hidden')
-      expect(noTodosElement).not.toHaveClass('invisible')
-      expect(noTodosElement).not.toHaveClass('opacity-0')
+      expect(noTodosElement).not.toHaveClass('tw-hidden')
+      expect(noTodosElement).not.toHaveClass('tw-invisible')
+      expect(noTodosElement).not.toHaveClass('tw-opacity-0')
 
       // Restore the original implementation
       vi.restoreAllMocks()

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,7 +7,7 @@ export default {
     './app/**/*.{ts,tsx}',
     './src/**/*.{ts,tsx}',
   ],
-  prefix: "",
+  prefix: "tw-",
   theme: {
     container: {
       center: true,


### PR DESCRIPTION
Closes #8 

Implemented the delete functionality for to-do items.

Added tests for delete workflow, including remove and cancel scenarios.

Assigned a temporary ID for each to-do items.

Integrated the Alert Dialog from shadcn/ui.

Set  prop to true in components.json to enable CSS variables for styling.

Added the 'tw-' prefix to Taiwind classess.

Updated the index.css and remove App.css.

Added a description of the delete functionality to FEATURES.md.